### PR TITLE
Critical Java 9 compatibility: Fix wrong path used for looking up resources on class loaders

### DIFF
--- a/src/main/java/org/bridj/Platform.java
+++ b/src/main/java/org/bridj/Platform.java
@@ -123,6 +123,7 @@ public class Platform {
             return in;
         }
 
+        path = path.substring(1);
         ClassLoader[] cls = {
             BridJ.class.getClassLoader(),
             Thread.currentThread().getContextClassLoader(),


### PR DESCRIPTION
After `BridJ.class.getResource(path)` failed various class loaders are tried to get the resource.
When used as an automatic module on the module path of a Java 9 application this call will always fail as you can only get resources from your own module with `Class#getResource()` even if they are opened explicitly.
But for getting a resource from the class loader, the path must not start with a slash or will never find anything.
Instead the path has to start without a slash and is always evaluated as absolute path.
This PR strips the leading slash that is explicitly added before for `Class#getResource()` where the leading slash is necessary to have the path treated as absolute path.

PS: Do you publicly release your builds?
Original repo seems pretty inactive.